### PR TITLE
Use ruby build version 2.1.1 to avoid the build failure issue on 2.x

### DIFF
--- a/data_bags/apps/example.json
+++ b/data_bags/apps/example.json
@@ -23,6 +23,6 @@
   },
   "rails_env" : "production",
   "ruby": {
-    "ruby-build-version" : "2.0.0-p353"
+    "ruby-build-version" : "2.1.1"
   }
 }


### PR DESCRIPTION
See more: https://github.com/sstephenson/ruby-build/issues/526
